### PR TITLE
Fix keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-hRNG	KEYWORD1funk     KEYWORD1
+hRNG	KEYWORD1
+funk	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 Randy	KEYWORD2
-init	KEYWORD2stop	KEYWORD2
+init	KEYWORD2
+stop	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
These changes are required for keyword highlighting of all the library's keywords in the Arduino IDE:
- Each keyword on its own line
- Correct keyword-identifier separator for funk keyword. The Arduino IDE requires a single true tab as separator, not spaces.