### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-hRNG  KEYWORD1
-funk  KEYWORD1
+hRNG	KEYWORD1
+funk	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Randy KEYWORD2
-init  KEYWORD2
-stop  KEYWORD2
+Randy	KEYWORD2
+init	KEYWORD2
+stop	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
Well, I guess I need to make another try at getting this merged since there has been no move to reopen my previous attempt (https://github.com/Tontie/hRNG/pull/1).

The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords
- http://forum.arduino.cc/index.php?topic=532704.msg3635394#msg3635394
- https://help.github.com/articles/merging-a-pull-request/